### PR TITLE
feat: add package to get burn summary

### DIFF
--- a/packages/kin-burn/.babelrc
+++ b/packages/kin-burn/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": [["@nrwl/web/babel", { "useBuiltIns": "usage" }]]
+}

--- a/packages/kin-burn/.eslintrc.json
+++ b/packages/kin-burn/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+  "extends": ["../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/kin-burn/README.md
+++ b/packages/kin-burn/README.md
@@ -1,0 +1,7 @@
+# kin-burn
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running unit tests
+
+Run `nx test kin-burn` to execute the unit tests via [Jest](https://jestjs.io).

--- a/packages/kin-burn/jest.config.js
+++ b/packages/kin-burn/jest.config.js
@@ -1,0 +1,15 @@
+module.exports = {
+  displayName: 'kin-burn',
+  preset: '../../jest.preset.js',
+  globals: {
+    'ts-jest': {
+      tsconfig: '<rootDir>/tsconfig.spec.json',
+    },
+  },
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.[tj]sx?$': 'ts-jest',
+  },
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
+  coverageDirectory: '../../coverage/packages/kin-burn',
+};

--- a/packages/kin-burn/package.json
+++ b/packages/kin-burn/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@kin-tools/kin-burn",
+  "version": "0.0.1"
+}

--- a/packages/kin-burn/project.json
+++ b/packages/kin-burn/project.json
@@ -1,0 +1,34 @@
+{
+  "root": "packages/kin-burn",
+  "sourceRoot": "packages/kin-burn/src",
+  "projectType": "library",
+  "targets": {
+    "build": {
+      "executor": "@nrwl/node:package",
+      "outputs": ["{options.outputPath}"],
+      "options": {
+        "outputPath": "dist/packages/kin-burn",
+        "tsConfig": "packages/kin-burn/tsconfig.lib.json",
+        "packageJson": "packages/kin-burn/package.json",
+        "main": "packages/kin-burn/src/index.ts",
+        "assets": ["packages/kin-burn/*.md"]
+      }
+    },
+    "lint": {
+      "executor": "@nrwl/linter:eslint",
+      "outputs": ["{options.outputFile}"],
+      "options": {
+        "lintFilePatterns": ["packages/kin-burn/**/*.ts"]
+      }
+    },
+    "test": {
+      "executor": "@nrwl/jest:jest",
+      "outputs": ["coverage/packages/kin-burn"],
+      "options": {
+        "jestConfig": "packages/kin-burn/jest.config.js",
+        "passWithNoTests": true
+      }
+    }
+  },
+  "tags": []
+}

--- a/packages/kin-burn/src/index.ts
+++ b/packages/kin-burn/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/kin-burn';

--- a/packages/kin-burn/src/lib/kin-burn.spec.ts
+++ b/packages/kin-burn/src/lib/kin-burn.spec.ts
@@ -1,0 +1,11 @@
+import { getSummary } from './kin-burn';
+
+describe('getSummary', () => {
+  it('should return a summary', async () => {
+    const summary = await getSummary();
+    expect(summary.burnt).toBeGreaterThan(135362);
+    expect(summary.max).toEqual(10000000000000);
+    expect(summary.percentage).toBeGreaterThan(0.00000134);
+    expect(summary.total).toBeLessThan(9999999864639);
+  });
+});

--- a/packages/kin-burn/src/lib/kin-burn.ts
+++ b/packages/kin-burn/src/lib/kin-burn.ts
@@ -1,0 +1,31 @@
+import { KIN_MINT_MAINNET } from '@kin-tools/kin-transaction';
+import { clusterApiUrl, Connection, PublicKey } from '@solana/web3.js';
+
+export interface BurnSummary {
+  burnt: number;
+  max: number;
+  percentage: number;
+  total: number;
+}
+
+export async function getSummary({
+  connection = new Connection(clusterApiUrl('mainnet-beta')),
+  mint = KIN_MINT_MAINNET,
+}: {
+  connection?: Connection;
+  mint?: string;
+} = {}): Promise<BurnSummary> {
+  const max = 10_000_000_000_000;
+  const total = await connection
+    .getTokenSupply(new PublicKey(mint))
+    .then((res) => res.value.uiAmount);
+  const burnt = max - total;
+  const percentage = Number(((burnt * 100) / max).toFixed(8));
+
+  return {
+    burnt,
+    max,
+    percentage,
+    total,
+  };
+}

--- a/packages/kin-burn/tsconfig.json
+++ b/packages/kin-burn/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/packages/kin-burn/tsconfig.lib.json
+++ b/packages/kin-burn/tsconfig.lib.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "exclude": ["**/*.spec.ts", "**/*.test.ts"],
+  "include": ["**/*.ts"]
+}

--- a/packages/kin-burn/tsconfig.spec.json
+++ b/packages/kin-burn/tsconfig.spec.json
@@ -1,0 +1,19 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "include": [
+    "**/*.test.ts",
+    "**/*.spec.ts",
+    "**/*.test.tsx",
+    "**/*.spec.tsx",
+    "**/*.test.js",
+    "**/*.spec.js",
+    "**/*.test.jsx",
+    "**/*.spec.jsx",
+    "**/*.d.ts"
+  ]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -15,6 +15,7 @@
     "skipDefaultLibCheck": true,
     "baseUrl": ".",
     "paths": {
+      "@kin-tools/kin-burn": ["packages/kin-burn/src/index.ts"],
       "@kin-tools/kin-memo": ["packages/kin-memo/src/index.ts"],
       "@kin-tools/kin-transaction": ["packages/kin-transaction/src/index.ts"]
     }

--- a/workspace.json
+++ b/workspace.json
@@ -1,6 +1,7 @@
 {
   "version": 2,
   "projects": {
+    "kin-burn": "packages/kin-burn",
     "kin-memo": "packages/kin-memo",
     "kin-transaction": "packages/kin-transaction"
   }


### PR DESCRIPTION
```ts
const summary = await getSummary();
console.log(JSON.stringify(summary, null, 2));
```
outputs something like 
```json
{
  "burnt": 135812.048828125,
  "max": 10000000000000,
  "percentage": 0.00000136,
  "total": 9999999864187.951
}
```